### PR TITLE
Add light/dark theme toggle

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,154 +1,15 @@
 import streamlit as st
 import pandas as pd
 from utils import configurar_pagina
+from style import apply_style, theme_toggle, COLORS
 
 # Configuração da página
 configurar_pagina("Gerenciador Financeiro")
 
-# Estilos CSS
-st.markdown("""
-<style>
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
-/* Reset e Estilos Base */
-body {
-    background-color: #0A0A0F;
-    color: #F5F5F5;
-    font-family: 'Inter', sans-serif;
-}
-
-#MainMenu, header, footer {visibility: hidden;}
-.css-18e3th9 {padding-top: 0 !important;}
-.css-1d391kg {padding-top: 3.5rem !important;}
-section[data-testid="stSidebar"] { 
-    display: none !important; 
-    width: 0px !important;
-}
-div[data-testid="collapsedControl"] { display: none !important; }
-
-/* Glassmorphism Effect */
-.glass-container {
-    background: rgba(138, 5, 190, 0.05);
-    backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: blur(10px);
-    border: 1px solid rgba(138, 5, 190, 0.2);
-    border-radius: 20px;
-    padding: 30px;
-    margin: 20px 0;
-}
-
-.card-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 25px;
-    padding: 20px;
-}
-
-.card-container {
-    background: linear-gradient(135deg, rgba(138, 5, 190, 0.1) 0%, rgba(181, 255, 90, 0.05) 100%);
-    border: 1px solid rgba(138, 5, 190, 0.3);
-    border-radius: 15px;
-    padding: 25px;
-    transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-    position: relative;
-    overflow: hidden;
-}
-
-.card-container::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 3px;
-    background: linear-gradient(90deg, #8A05BE, #B5FF5A);
-    transform: scaleX(0);
-    transition: transform 0.4s ease;
-}
-
-.card-container:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 8px 25px rgba(138, 5, 190, 0.2);
-    border-color: rgba(138, 5, 190, 0.5);
-}
-
-.card-container:hover::before {
-    transform: scaleX(1);
-}
-
-.card-title {
-    font-size: 1.25rem;
-    font-weight: 600;
-    color: #B5FF5A;
-    margin-bottom: 12px;
-    display: flex;
-    align-items: center;
-    gap: 10px;
-}
-
-.card-desc {
-    font-size: 0.9rem;
-    color: rgba(245, 245, 245, 0.7);
-    line-height: 1.5;
-}
-
-/* Animação de brilho */
-@keyframes glow {
-    0% { box-shadow: 0 0 5px rgba(138, 5, 190, 0.2); }
-    50% { box-shadow: 0 0 20px rgba(138, 5, 190, 0.4); }
-    100% { box-shadow: 0 0 5px rgba(138, 5, 190, 0.2); }
-}
-
-/* Header Estilizado */
-.header-container {
-    text-align: center;
-    padding: 40px 20px;
-    background: linear-gradient(180deg, rgba(138, 5, 190, 0.1) 0%, rgba(10, 10, 15, 0) 100%);
-    border-radius: 0 0 30px 30px;
-    margin-bottom: 40px;
-}
-
-.header-title {
-    background: linear-gradient(90deg, #8A05BE, #B5FF5A);
-    -webkit-background-clip: text;
-    background-clip: text;
-    color: transparent;
-    font-size: 2.5rem;
-    font-weight: 700;
-    margin-bottom: 15px;
-}
-
-.header-subtitle {
-    color: rgba(245, 245, 245, 0.7);
-    font-size: 1.1rem;
-    max-width: 600px;
-    margin: 0 auto;
-}
-
-/* Footer Estilizado */
-.footer {
-    text-align: center;
-    padding: 30px;
-    background: linear-gradient(0deg, rgba(138, 5, 190, 0.1) 0%, rgba(10, 10, 15, 0) 100%);
-    margin-top: 60px;
-}
-
-.footer-text {
-    color: rgba(245, 245, 245, 0.5);
-    font-size: 0.9rem;
-}
-
-/* Responsividade */
-@media (max-width: 768px) {
-    .card-grid {
-        grid-template-columns: 1fr;
-    }
-    .header-title {
-        font-size: 2rem;
-    }
-}
-</style>
-""", unsafe_allow_html=True)
+# Seleção de tema e aplicação de estilos
+theme = theme_toggle()
+apply_style(theme)
 
 # Header
 st.markdown("""

--- a/pages/0_Dashboard.py
+++ b/pages/0_Dashboard.py
@@ -3,8 +3,13 @@ import pandas as pd
 import plotly.express as px
 from utils import get_receitas, get_gastos, get_contas, get_dividas, get_parcelas, add_meta, get_metas, configurar_pagina
 import datetime
+from style import apply_style, theme_toggle
 
 configurar_pagina("Dashboard")
+
+# Seleção de tema e aplicação de estilos
+theme = theme_toggle()
+apply_style(theme)
 
 # Estilo moderno e futurista
 st.markdown("""

--- a/pages/1_Gastos.py
+++ b/pages/1_Gastos.py
@@ -3,12 +3,13 @@ import datetime
 import pandas as pd
 import plotly.express as px
 from utils import add_gasto, update_gasto, delete_gasto, get_gastos, rerun, configurar_pagina
-from style import apply_style, format_currency, COLORS, PLOTLY_LAYOUT
+from style import apply_style, theme_toggle, format_currency, COLORS, PLOTLY_LAYOUT
 
 configurar_pagina("Gastos")
 
-# Aplicar estilos
-apply_style()
+# Seleção de tema
+theme = theme_toggle()
+apply_style(theme)
 
 # Botão de retorno
 if st.button("🔙 Voltar à Página Inicial"):

--- a/pages/2_Receitas.py
+++ b/pages/2_Receitas.py
@@ -3,12 +3,13 @@ import datetime
 import pandas as pd
 import plotly.express as px
 from utils import add_receita, update_receita, delete_receita, get_receitas, rerun, configurar_pagina
-from style import apply_style, format_currency, COLORS, PLOTLY_LAYOUT
+from style import apply_style, theme_toggle, format_currency, COLORS, PLOTLY_LAYOUT
 
 configurar_pagina("Receitas")
 
-# Aplicar estilos
-apply_style()
+# Seleção de tema
+theme = theme_toggle()
+apply_style(theme)
 
 # Botão voltar para home
 if st.button("🔙 Voltar à Página Inicial"):

--- a/pages/3_Compromissos.py
+++ b/pages/3_Compromissos.py
@@ -4,12 +4,13 @@ import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
 from utils import add_compromisso, update_compromisso, delete_compromisso, get_compromissos, rerun, configurar_pagina
-from style import apply_style, format_currency, COLORS, PLOTLY_LAYOUT
+from style import apply_style, theme_toggle, format_currency, COLORS, PLOTLY_LAYOUT
 
 configurar_pagina("Compromissos Financeiros")
 
-# Aplicar estilos
-apply_style()
+# Seleção de tema
+theme = theme_toggle()
+apply_style(theme)
 
 # Botão para voltar
 if st.button("🔙 Voltar à Página Inicial"):

--- a/pages/4_Contas.py
+++ b/pages/4_Contas.py
@@ -1,12 +1,13 @@
 import streamlit as st
 import datetime
 from utils import add_conta, update_conta, delete_conta, get_contas, rerun, configurar_pagina
-from style import apply_style, format_currency, COLORS
+from style import apply_style, theme_toggle, format_currency, COLORS
 
 configurar_pagina("Contas")
 
-# Aplicar estilos
-apply_style()
+# Seleção de tema
+theme = theme_toggle()
+apply_style(theme)
 
 # Botão de retorno para a página inicial
 if st.button("🔙 Voltar à Página Inicial"):

--- a/pages/5_Investimentos.py
+++ b/pages/5_Investimentos.py
@@ -4,12 +4,13 @@ import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
 from utils import add_investimento, update_investimento, delete_investimento, get_investimentos, rerun, configurar_pagina
-from style import apply_style, format_currency, COLORS, PLOTLY_LAYOUT
+from style import apply_style, theme_toggle, format_currency, COLORS, PLOTLY_LAYOUT
 
 configurar_pagina("Investimentos")
 
-# Aplicar estilos
-apply_style()
+# Seleção de tema
+theme = theme_toggle()
+apply_style(theme)
 
 # Botão para voltar
 if st.button("🔙 Voltar à Página Inicial"):

--- a/pages/6_Orcamentos.py
+++ b/pages/6_Orcamentos.py
@@ -5,12 +5,13 @@ import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
 from utils import add_orcamento, update_orcamento, delete_orcamento, get_orcamentos, get_gastos, get_categorias, calcular_fluxo_caixa_mensal, rerun, configurar_pagina
-from style import apply_style, format_currency, COLORS, PLOTLY_LAYOUT
+from style import apply_style, theme_toggle, format_currency, COLORS, PLOTLY_LAYOUT
 
 configurar_pagina("Orçamentos")
 
-# Aplicar estilos
-apply_style()
+# Seleção de tema
+theme = theme_toggle()
+apply_style(theme)
 
 # Botão para voltar
 if st.button("🔙 Voltar à Página Inicial"):

--- a/pages/7_Metas.py
+++ b/pages/7_Metas.py
@@ -3,12 +3,13 @@ import datetime
 import pandas as pd
 import plotly.express as px
 from utils import add_meta, update_meta, delete_meta, get_metas, rerun, configurar_pagina
-from style import apply_style, format_currency, COLORS, PLOTLY_LAYOUT
+from style import apply_style, theme_toggle, format_currency, COLORS, PLOTLY_LAYOUT
 
 configurar_pagina("Metas")
 
-# Aplicar estilos
-apply_style()
+# Seleção de tema
+theme = theme_toggle()
+apply_style(theme)
 
 # Botão para voltar
 if st.button("🔙 Voltar à Página Inicial"):

--- a/pages/8_Resumo_mensal.py
+++ b/pages/8_Resumo_mensal.py
@@ -3,12 +3,13 @@ import datetime
 import pandas as pd
 import plotly.express as px
 from utils import get_receitas, get_gastos, get_contas, get_dividas, get_parcelas, add_meta, get_metas, configurar_pagina
-from style import apply_style, format_currency, COLORS, PLOTLY_LAYOUT
+from style import apply_style, theme_toggle, format_currency, COLORS, PLOTLY_LAYOUT
 
 configurar_pagina("Resumo Mensal")
 
-# Aplicar estilos
-apply_style()
+# Seleção de tema
+theme = theme_toggle()
+apply_style(theme)
 
 # Botão voltar
 if st.button("🔙 Voltar à Página Inicial"):

--- a/pages/9_Insights.py
+++ b/pages/9_Insights.py
@@ -3,12 +3,13 @@ import datetime
 import pandas as pd
 import plotly.express as px
 from utils import get_receitas, get_gastos, get_contas, get_dividas, get_parcelas, add_meta, get_metas, configurar_pagina
-from style import apply_style, format_currency, COLORS, PLOTLY_LAYOUT
+from style import apply_style, theme_toggle, format_currency, COLORS, PLOTLY_LAYOUT
 
 configurar_pagina("Insights")
 
-# Aplicar estilos
-apply_style()
+# Seleção de tema
+theme = theme_toggle()
+apply_style(theme)
 
 # Botão voltar para home
 if st.button("🔙 Voltar à Página Inicial"):

--- a/style.py
+++ b/style.py
@@ -1,22 +1,36 @@
-"""
-Estilos centralizados para o Gerenciador Financeiro
-"""
+"""Estilos centralizados e temas para o Gerenciador Financeiro."""
 
-# Cores principais
-COLORS = {
-    'primary': '#8A05BE',      # Roxo principal
-    'secondary': '#B5FF5A',    # Verde neon
-    'background': '#0A0A0F',   # Fundo escuro
-    'surface': '#1E1E1E',      # Superfície dos cards
-    'text': '#F5F5F5',         # Texto principal
-    'text_secondary': 'rgba(245, 245, 245, 0.7)',  # Texto secundário
-    'success': '#B5FF5A',      # Sucesso (verde)
-    'warning': '#FFB74D',      # Alerta (laranja)
-    'error': '#FF4D4D',        # Erro (vermelho)
+# Paletas de cores para os temas claro e escuro
+THEMES = {
+    "dark": {
+        "primary": "#8A05BE",          # Roxo principal
+        "secondary": "#B5FF5A",        # Verde neon
+        "background": "#0A0A0F",       # Fundo escuro
+        "surface": "rgba(10, 10, 15, 0.5)",
+        "text": "#F5F5F5",             # Texto principal
+        "text_secondary": "rgba(245, 245, 245, 0.7)",
+        "success": "#B5FF5A",
+        "warning": "#FFB74D",
+        "error": "#FF4D4D",
+    },
+    "light": {
+        "primary": "#8A05BE",
+        "secondary": "#B5FF5A",
+        "background": "#FFFFFF",
+        "surface": "rgba(255, 255, 255, 0.8)",
+        "text": "#0A0A0F",
+        "text_secondary": "rgba(10, 10, 15, 0.7)",
+        "success": "#4CAF50",
+        "warning": "#FFB74D",
+        "error": "#FF4D4D",
+    },
 }
 
+# Cores ativas (inicialmente tema escuro)
+COLORS = THEMES["dark"]
+
 # Estilos CSS comuns
-STYLES = """
+STYLES_TEMPLATE = """
 <style>
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
@@ -81,9 +95,79 @@ div[data-testid="collapsedControl"] { display: none !important; }
     margin: 20px 0;
 }
 
+/* Grid de cards da página inicial */
+.card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 25px;
+    padding: 20px;
+}
+
+/* Cartão da página inicial */
+.card-container {
+    background: linear-gradient(135deg, rgba(138, 5, 190, 0.1) 0%%, rgba(181, 255, 90, 0.05) 100%%);
+    border: 1px solid rgba(138, 5, 190, 0.3);
+    border-radius: 15px;
+    padding: 25px;
+    transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+    position: relative;
+    overflow: hidden;
+}
+
+.card-container::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, %(primary)s, %(secondary)s);
+    transform: scaleX(0);
+    transition: transform 0.4s ease;
+}
+
+.card-container:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 8px 25px rgba(138, 5, 190, 0.2);
+    border-color: rgba(138, 5, 190, 0.5);
+}
+
+.card-container:hover::before {
+    transform: scaleX(1);
+}
+
+.card-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: %(secondary)s;
+    margin-bottom: 12px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.card-desc {
+    font-size: 0.9rem;
+    color: %(text_secondary)s;
+    line-height: 1.5;
+}
+
+/* Footer */
+.footer {
+    text-align: center;
+    padding: 30px;
+    background: linear-gradient(0deg, rgba(138, 5, 190, 0.1) 0%%, rgba(10, 10, 15, 0) 100%%);
+    margin-top: 60px;
+}
+
+.footer-text {
+    color: %(text_secondary)s;
+    font-size: 0.9rem;
+}
+
 /* Cards */
 .card {
-    background: rgba(10, 10, 15, 0.5);
+    background: %(surface)s;
     backdrop-filter: blur(10px);
     border: 1px solid rgba(138, 5, 190, 0.2);
     border-radius: 15px;
@@ -99,7 +183,7 @@ div[data-testid="collapsedControl"] { display: none !important; }
 
 /* Métricas */
 .metric-card {
-    background: rgba(10, 10, 15, 0.5);
+    background: %(surface)s;
     backdrop-filter: blur(10px);
     border: 1px solid rgba(138, 5, 190, 0.2);
     border-radius: 15px;
@@ -193,7 +277,7 @@ div[data-testid="collapsedControl"] { display: none !important; }
 
 /* Tabelas */
 .dataframe {
-    background: rgba(10, 10, 15, 0.5);
+    background: %(surface)s;
     border-radius: 10px;
     border: 1px solid rgba(138, 5, 190, 0.2);
 }
@@ -211,7 +295,7 @@ div[data-testid="collapsedControl"] { display: none !important; }
 
 /* Gráficos */
 .plot-container {
-    background: rgba(10, 10, 15, 0.5);
+    background: %(surface)s;
     backdrop-filter: blur(10px);
     border: 1px solid rgba(138, 5, 190, 0.2);
     border-radius: 15px;
@@ -229,12 +313,70 @@ div[data-testid="collapsedControl"] { display: none !important; }
     }
 }
 </style>
-""" % COLORS
+"""
 
-def apply_style():
-    """Aplica os estilos definidos na página atual."""
+def _build_plotly_layout(colors: dict, theme: str) -> dict:
+    """Retorna o layout padrão do Plotly de acordo com o tema."""
+    template = "plotly_dark" if theme == "dark" else "plotly_white"
+    return {
+        "template": template,
+        "plot_bgcolor": "rgba(0,0,0,0)",
+        "paper_bgcolor": "rgba(0,0,0,0)",
+        "font": {
+            "family": "Inter",
+            "color": colors["text"],
+        },
+        "title": {"font": {"size": 20, "color": colors["secondary"]}},
+        "xaxis": {
+            "gridcolor": "rgba(138, 5, 190, 0.1)",
+            "tickfont": {"color": colors["text_secondary"]},
+        },
+        "yaxis": {
+            "gridcolor": "rgba(138, 5, 190, 0.1)",
+            "tickfont": {"color": colors["text_secondary"]},
+        },
+    }
+
+
+def apply_style(theme: str | None = None):
+    """Aplica os estilos definidos na página atual.
+
+    O tema pode ser "dark" ou "light". Se nenhum for informado, utiliza o
+    valor armazenado em ``st.session_state['theme']`` ou ``"dark"``.
+    """
     import streamlit as st
-    st.markdown(STYLES, unsafe_allow_html=True)
+
+    if theme is None:
+        theme = st.session_state.get("theme", "dark")
+
+    theme = theme if theme in THEMES else "dark"
+
+    # Atualiza cores e layout globais
+    global COLORS, PLOTLY_LAYOUT
+    COLORS = THEMES[theme]
+    PLOTLY_LAYOUT = _build_plotly_layout(COLORS, theme)
+
+    st.session_state["theme"] = theme
+    st.markdown(STYLES_TEMPLATE % COLORS, unsafe_allow_html=True)
+
+
+def theme_toggle(label: str = "Tema") -> str:
+    """Exibe um seletor de tema e retorna o tema escolhido."""
+    import streamlit as st
+
+    current = st.session_state.get("theme", "dark")
+    option = st.radio(
+        label,
+        ["Claro", "Escuro"],
+        horizontal=True,
+        index=0 if current == "light" else 1,
+    )
+    theme = "light" if option == "Claro" else "dark"
+    st.session_state["theme"] = theme
+    return theme
+
+# Layout padrão inicial para Plotly
+PLOTLY_LAYOUT = _build_plotly_layout(COLORS, "dark")
 
 def format_currency(value):
     """Formata um valor para moeda brasileira."""
@@ -243,28 +385,3 @@ def format_currency(value):
 def format_percent(value):
     """Formata um valor para porcentagem."""
     return f"{value:.1f}%"
-
-# Configurações padrão para gráficos Plotly
-PLOTLY_LAYOUT = {
-    "template": "plotly_dark",
-    "plot_bgcolor": "rgba(0,0,0,0)",
-    "paper_bgcolor": "rgba(0,0,0,0)",
-    "font": {
-        "family": "Inter",
-        "color": COLORS['text']
-    },
-    "title": {
-        "font": {
-            "size": 20,
-            "color": COLORS['secondary']
-        }
-    },
-    "xaxis": {
-        "gridcolor": "rgba(138, 5, 190, 0.1)",
-        "tickfont": {"color": COLORS['text_secondary']}
-    },
-    "yaxis": {
-        "gridcolor": "rgba(138, 5, 190, 0.1)",
-        "tickfont": {"color": COLORS['text_secondary']}
-    }
-}


### PR DESCRIPTION
## Summary
- add centralized theme definitions and style helpers
- support light and dark themes with theme toggle component
- update pages to allow choosing theme and apply global styles
- apply new styles on main page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686ebe465c50832282816d4d36d852ed